### PR TITLE
ブロックエディターをダイレクト編集した時にtypographyスタイルが適用されない問題対応

### DIFF
--- a/themes/develop/_entry.twig
+++ b/themes/develop/_entry.twig
@@ -28,6 +28,15 @@
 {% set relationalItems = entryTagRelational.items|slice(0, 2) %}
 {% set offsetRelationalItems = entryTagRelational.items|slice(2) %}
 
+{% block headJs %}
+  {% if touch('Touch_EditInplace') %}
+    {{ parent() }}
+    <script>
+      ACMS.Ready(function() { ACMS.Config.blockEditorConfig.editorProps.editorProps.attributes.class = 'prose'; });
+    </script>
+  {% endif %}
+{% endblock %}
+
 {% block main %}
   <article>
     {{ include('/include/entry/body.twig', { sns_share: true }) }}


### PR DESCRIPTION
ブロックエディターをダイレクト編集した際に、Tailwind CSS の @tailwindcss/typography スタイルがエディター内にも適用されるようにしました。