### PR TITLE
記事一覧のマークアップを改善

### DIFF
--- a/themes/develop/_entry.twig
+++ b/themes/develop/_entry.twig
@@ -42,7 +42,7 @@
     {{ include('/include/entry/body.twig', { sns_share: true }) }}
 
     {% if entryTagRelational.items is not empty %}
-      <section class="mt-16 md:mt-20 grid gap-y-8">
+      <aside class="mt-16 md:mt-20 grid gap-y-8">
         <div>
           {{ include('/admin/module/setting.twig', { moduleInfo: tagCloud.moduleInfo }) }}
           <h2 class="text-lg font-bold">関連記事</h2>
@@ -68,7 +68,7 @@
             {% endif %}
           </div>
         </div>
-      </section>
+      </aside>
     {% endif %}
   </article>
 {% endblock %}

--- a/themes/develop/_entry.twig
+++ b/themes/develop/_entry.twig
@@ -11,7 +11,7 @@
 {% set entryTagRelational =
   module(
     'V2_Entry_TagRelational',
-    'hoge',
+    null,
     {
       bid: null,
       cid: null,
@@ -57,14 +57,17 @@
           </p>
         </div>
 
-        {{
-          include(
-            '/include/entry/tag-relational-card.twig',
-            { items: relationalItems, moduleInfo: entryTagRelational.moduleInfo }
-          )
-        }}
+        <div>
+          {{ include('/admin/module/setting.twig', { moduleInfo: entryTagRelational.moduleInfo }) }}
 
-        {{ include('/include/entry/tag-relational-tiny.twig', { items: offsetRelationalItems }) }}
+          <div class="grid gap-y-8">
+            {{ include('/include/entry/tag-relational-card.twig', { items: relationalItems }) }}
+
+            {% if offsetRelationalItems is not empty %}
+              {{ include('/include/entry/tag-relational-tiny.twig', { items: offsetRelationalItems }) }}
+            {% endif %}
+          </div>
+        </div>
       </section>
     {% endif %}
   </article>

--- a/themes/develop/include/entry/summary-card.twig
+++ b/themes/develop/include/entry/summary-card.twig
@@ -51,7 +51,7 @@
           aria-labelledby="card-entry{{ entry.eid }}"
           class="col-span-12 {{ column_class|default('sm:col-span-6') }}"
         >
-          <a href="{{ entry.url }}" class="block w-full text-sm hover:opacity-70">
+          <a href="{{ entry.url }}" class="block w-full hover:opacity-70">
             {% if entry.mainImage and entry.mainImage.path %}
               <img
                 src="{{ entry.mainImage.path|resizeImg(700) }}"
@@ -73,13 +73,13 @@
                 class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
               />
             {% endif %}
-            <h3 id="card-entry{{ entry.eid }}" class="mt-3 text-gray-900 text-lg font-bold line-clamp-2">
+            <h3 id="card-entry{{ entry.eid }}" class="mt-3 text-gray-900 text-md md:text-lg font-bold line-clamp-2">
               {{ entry.title }}
             </h3>
-            <p class="mt-2 line-clamp-2">
+            <p class="mt-2 text-sm line-clamp-2">
               {{ entry.summary }}
             </p>
-            <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-2">
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-2 text-sm">
               <p class="text-gray-500">
                 <span class="sr-only">公開日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
                     entry.datetime|date('Y年m月d日')
@@ -92,14 +92,14 @@
               {% endif %}
             </div>
             {% if entry.category.items %}
-              <p class="mt-2 text-gray-500 font-bold">
+              <p class="mt-2 text-gray-500 font-bold text-sm">
                 <span class="sr-only">カテゴリー</span>{{ entry.category.items[0].name }}
               </p>
             {% endif %}
             {% if entry.tags %}
               <ul class="mt-2 flex flex-wrap gap-x-3 gap-y-1" aria-label="タグ">
                 {% for tag in entry.tags %}
-                  <li class="text-gray-500">#{{ tag.name }}</li>
+                  <li class="text-gray-500 text-sm">#{{ tag.name }}</li>
                 {% endfor %}
               </ul>
             {% endif %}

--- a/themes/develop/include/entry/summary-card.twig
+++ b/themes/develop/include/entry/summary-card.twig
@@ -19,10 +19,18 @@
   )
 %}
 
-<section>
-  <h2 class="sr-only">記事一覧</h2>
+{% if touch('Touch_Keyword') %}
+  <h1 class="text-gray-900 text-2xl font-bold mb-8">
+    {{ KEYWORD }} の検索結果：
 
+    {{ entrySummary.pagination.total }}件
+  </h1>
+{% endif %}
+
+<section>
   {{ include('/admin/module/setting.twig', { moduleInfo: entrySummary.moduleInfo }) }}
+
+  <h2 class="sr-only">記事一覧</h2>
 
   {% if entrySummary.items is empty %}
     <p class="text-gray-900 text-lg text-center">
@@ -30,81 +38,76 @@
     </p>
   {% endif %}
 
-  {% if touch('Touch_Keyword') %}
-    <p class="text-gray-900 text-2xl font-bold mb-8">
-      {{ KEYWORD }} の検索結果：
+  {% if entrySummary.items is not empty %}
+    {% if PAGE >= 2 %}
+      <p class="sr-only">
+        {{ PAGE }}ページ目
+      </p>
+    {% endif %}
 
-      {{ entrySummary.pagination.total }}件
-    </p>
-  {% endif %}
-
-  {% if PAGE >= 2 %}
-    <p class="sr-only">
-      {{ PAGE }}ページ目
-    </p>
-  {% endif %}
-
-  <div class="grid grid-cols-12 pb-10 gap-y-8 gap-x-4 sm:gap-8">
-    {% for entry in entrySummary.items %}
-      <article
-        aria-labelledby="card-entry{{ entry.eid }}"
-        class="col-span-12 {{ column_class|default('sm:col-span-6') }}"
-      >
-        <a href="{{ entry.url }}" class="block w-full text-sm hover:opacity-70">
-          {% if entry.mainImage and entry.mainImage.path %}
-            <img
-              src="{{ entry.mainImage.path|resizeImg(700) }}"
-              width="700"
-              height="{{ entry.mainImage.ratio|getHeightFromRatio(700) }}"
-              alt="{{ entry.mainImage.alt }}"
-              loading="lazy"
-              decoding="async"
-              class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
-            />
-          {% else %}
-            <img
-              src="/images/default/noimage.gif"
-              width="640"
-              height="480"
-              alt=""
-              loading="lazy"
-              decoding="async"
-              class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
-            />
-          {% endif %}
-          <h3 id="card-entry{{ entry.eid }}" class="mt-3 text-gray-900 text-lg font-bold line-clamp-2">
-            {{ entry.title }}
-          </h3>
-          <p class="mt-2 line-clamp-2">
-            {{ entry.summary }}
-          </p>
-          <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-2">
-            <p class="text-gray-500">
-              <span class="sr-only">投稿日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
-                  entry.datetime|date('Y年m月d日')
-                }}</time>
+    <div class="grid grid-cols-12 pb-10 gap-y-8 gap-x-4 sm:gap-8">
+      {% for entry in entrySummary.items %}
+        <article
+          aria-labelledby="card-entry{{ entry.eid }}"
+          class="col-span-12 {{ column_class|default('sm:col-span-6') }}"
+        >
+          <a href="{{ entry.url }}" class="block w-full text-sm hover:opacity-70">
+            {% if entry.mainImage and entry.mainImage.path %}
+              <img
+                src="{{ entry.mainImage.path|resizeImg(700) }}"
+                width="700"
+                height="{{ entry.mainImage.ratio|getHeightFromRatio(700) }}"
+                alt="{{ entry.mainImage.alt }}"
+                loading="lazy"
+                decoding="async"
+                class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
+              />
+            {% else %}
+              <img
+                src="/images/default/noimage.gif"
+                width="640"
+                height="480"
+                alt=""
+                loading="lazy"
+                decoding="async"
+                class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
+              />
+            {% endif %}
+            <h3 id="card-entry{{ entry.eid }}" class="mt-3 text-gray-900 text-lg font-bold line-clamp-2">
+              {{ entry.title }}
+            </h3>
+            <p class="mt-2 line-clamp-2">
+              {{ entry.summary }}
             </p>
-            {% if entry.isNew %}
-              <p class="px-2 py-1 rounded-full bg-gray-50 text-gray-900 text-xs">
-                NEW
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-2">
+              <p class="text-gray-500">
+                <span class="sr-only">投稿日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
+                    entry.datetime|date('Y年m月d日')
+                  }}</time>
+              </p>
+              {% if entry.isNew %}
+                <p class="px-2 py-1 rounded-full bg-gray-50 text-gray-900 text-xs">
+                  NEW
+                </p>
+              {% endif %}
+            </div>
+            {% if entry.category.items %}
+              <p class="mt-2 text-gray-500 font-bold">
+                <span class="sr-only">カテゴリー</span>{{ entry.category.items[0].name }}
               </p>
             {% endif %}
-          </div>
-          {% if entry.category.items %}
-            <p class="mt-2 text-gray-500 font-bold">
-              <span class="sr-only">カテゴリー</span>{{ entry.category.items[0].name }}
-            </p>
-          {% endif %}
-          {% if entry.tags %}
-            <ul class="mt-2 flex flex-wrap gap-x-3 gap-y-1" aria-label="タグ" role="list">
-              {% for tag in entry.tags %}
-                <li class="text-gray-500">#{{ tag.name }}</li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-        </a>
-      </article>
-    {% endfor %}
-  </div>
+            {% if entry.tags %}
+              <ul class="mt-2 flex flex-wrap gap-x-3 gap-y-1" aria-label="タグ" role="list">
+                {% for tag in entry.tags %}
+                  <li class="text-gray-500">#{{ tag.name }}</li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </a>
+        </article>
+      {% endfor %}
+    </div>
+  {% endif %}
+
   {{ include('/include/parts/pagination.twig', { pagination: entrySummary.pagination }) }}
 </section>

--- a/themes/develop/include/entry/summary-card.twig
+++ b/themes/develop/include/entry/summary-card.twig
@@ -81,7 +81,7 @@
             </p>
             <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-2">
               <p class="text-gray-500">
-                <span class="sr-only">投稿日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
+                <span class="sr-only">公開日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
                     entry.datetime|date('Y年m月d日')
                   }}</time>
               </p>

--- a/themes/develop/include/entry/summary-card.twig
+++ b/themes/develop/include/entry/summary-card.twig
@@ -78,14 +78,14 @@
           <p class="mt-2 line-clamp-2">
             {{ entry.summary }}
           </p>
-          <div class="flex items-center mt-2">
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-2">
             <p class="text-gray-500">
               <span class="sr-only">投稿日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
                   entry.datetime|date('Y年m月d日')
                 }}</time>
             </p>
             {% if entry.isNew %}
-              <p class="ml-2 px-2 py-1 rounded-full bg-gray-50 text-gray-900 text-xs">
+              <p class="px-2 py-1 rounded-full bg-gray-50 text-gray-900 text-xs">
                 NEW
               </p>
             {% endif %}

--- a/themes/develop/include/entry/summary-card.twig
+++ b/themes/develop/include/entry/summary-card.twig
@@ -73,7 +73,7 @@
                 class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
               />
             {% endif %}
-            <h3 id="card-entry{{ entry.eid }}" class="mt-3 text-gray-900 text-md md:text-lg font-bold line-clamp-2">
+            <h3 id="card-entry{{ entry.eid }}" class="mt-3 text-gray-900 text-base md:text-lg font-bold line-clamp-2">
               {{ entry.title }}
             </h3>
             <p class="mt-2 text-sm line-clamp-2">

--- a/themes/develop/include/entry/summary-card.twig
+++ b/themes/develop/include/entry/summary-card.twig
@@ -97,7 +97,7 @@
               </p>
             {% endif %}
             {% if entry.tags %}
-              <ul class="mt-2 flex flex-wrap gap-x-3 gap-y-1" aria-label="タグ" role="list">
+              <ul class="mt-2 flex flex-wrap gap-x-3 gap-y-1" aria-label="タグ">
                 {% for tag in entry.tags %}
                   <li class="text-gray-500">#{{ tag.name }}</li>
                 {% endfor %}

--- a/themes/develop/include/entry/summary-card.twig
+++ b/themes/develop/include/entry/summary-card.twig
@@ -19,7 +19,9 @@
   )
 %}
 
-<div>
+<section>
+  <h2 class="sr-only">記事一覧</h2>
+
   {{ include('/admin/module/setting.twig', { moduleInfo: entrySummary.moduleInfo }) }}
 
   {% if entrySummary.items is empty %}
@@ -36,15 +38,24 @@
     </p>
   {% endif %}
 
+  {% if PAGE >= 2 %}
+    <p class="sr-only">
+      {{ PAGE }}ページ目
+    </p>
+  {% endif %}
+
   <div class="grid grid-cols-12 pb-10 gap-y-8 gap-x-4 sm:gap-8">
     {% for entry in entrySummary.items %}
-      <div class="flex flex-col items-start space-y-3 col-span-12 {{ column_class|default('sm:col-span-6') }}">
+      <article
+        aria-labelledby="card-entry{{ entry.eid }}"
+        class="col-span-12 {{ column_class|default('sm:col-span-6') }}"
+      >
         <a href="{{ entry.url }}" class="block w-full text-sm hover:opacity-70">
           {% if entry.mainImage.path %}
             <img
-              src="{{ entry.mainImage.path|resizeImg(686, 386) }}"
-              width="343"
-              height="193"
+              src="{{ entry.mainImage.path|resizeImg(700) }}"
+              width="700"
+              height="{{ entry.mainImage.ratio|getHeightFromRatio(700) }}"
               alt="{{ entry.mainImage.alt }}"
               loading="lazy"
               decoding="async"
@@ -53,21 +64,25 @@
           {% else %}
             <img
               src="/images/default/noimage.gif"
-              width="343"
-              height="193"
-              alt="画像なし"
+              width="640"
+              height="480"
+              alt=""
               loading="lazy"
               decoding="async"
               class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
             />
           {% endif %}
-          <h2 class="mt-3 text-gray-900 text-lg font-bold line-clamp-2">{{ entry.title }}</h2>
+          <h3 id="card-entry{{ entry.eid }}" class="mt-3 text-gray-900 text-lg font-bold line-clamp-2">
+            {{ entry.title }}
+          </h3>
           <p class="mt-2 line-clamp-2">
             {{ entry.summary }}
           </p>
           <div class="flex items-center mt-2">
             <p class="text-gray-500">
-              <time datetime="{{ entry.datetime|date('Y-m-d') }}">{{ entry.datetime|date('Y年m月d日') }}</time>
+              <span class="sr-only">投稿日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
+                  entry.datetime|date('Y年m月d日')
+                }}</time>
             </p>
             {% if entry.isNew %}
               <p class="ml-2 px-2 py-1 rounded-full bg-gray-50 text-gray-900 text-xs">
@@ -77,19 +92,19 @@
           </div>
           {% if entry.category.items %}
             <p class="mt-2 text-gray-500 font-bold">
-              {{ entry.category.items[0].name }}
+              <span class="sr-only">カテゴリー</span>{{ entry.category.items[0].name }}
             </p>
           {% endif %}
           {% if entry.tags %}
-            <ul class="flex flex-wrap gap-x-3 gap-y-1 mt-2 text-gray-500">
+            <ul class="mt-2 flex flex-wrap gap-x-3 gap-y-1" aria-label="タグ" role="list">
               {% for tag in entry.tags %}
-                <li>#{{ tag.name }}</li>
+                <li class="text-gray-500">#{{ tag.name }}</li>
               {% endfor %}
             </ul>
           {% endif %}
         </a>
-      </div>
+      </article>
     {% endfor %}
   </div>
   {{ include('/include/parts/pagination.twig', { pagination: entrySummary.pagination }) }}
-</div>
+</section>

--- a/themes/develop/include/entry/summary-card.twig
+++ b/themes/develop/include/entry/summary-card.twig
@@ -97,7 +97,7 @@
               </p>
             {% endif %}
             {% if entry.tags %}
-              <ul class="mt-2 flex flex-wrap gap-x-3 gap-y-1" aria-label="タグ">
+              <ul class="mt-2 flex flex-wrap gap-x-3 gap-y-1">
                 {% for tag in entry.tags %}
                   <li class="text-gray-500 text-sm">#{{ tag.name }}</li>
                 {% endfor %}

--- a/themes/develop/include/entry/summary-card.twig
+++ b/themes/develop/include/entry/summary-card.twig
@@ -51,7 +51,7 @@
         class="col-span-12 {{ column_class|default('sm:col-span-6') }}"
       >
         <a href="{{ entry.url }}" class="block w-full text-sm hover:opacity-70">
-          {% if entry.mainImage.path %}
+          {% if entry.mainImage and entry.mainImage.path %}
             <img
               src="{{ entry.mainImage.path|resizeImg(700) }}"
               width="700"

--- a/themes/develop/include/entry/summary-tiny.twig
+++ b/themes/develop/include/entry/summary-tiny.twig
@@ -29,7 +29,7 @@
   {% endif %}
 
   {% if entrySummary.items is not empty %}
-    <ul class="{{ wrapper_class|default('grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-4') }}" role="list">
+    <ul class="{{ wrapper_class|default('grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-4') }}">
       {% for entry in entrySummary.items %}
         <li>
           <a href="{{ entry.url }}" class="flex items-start gap-2 hover:opacity-70">

--- a/themes/develop/include/entry/summary-tiny.twig
+++ b/themes/develop/include/entry/summary-tiny.twig
@@ -37,8 +37,8 @@
               {% if entry.mainImage and entry.mainImage.path %}
                 <img
                   src="{{ entry.mainImage.path|resizeImg(192, 192) }}"
-                  width="96"
-                  height="96"
+                  width="192"
+                  height="192"
                   alt="{{ entry.mainImage.alt }}"
                   loading="lazy"
                   decoding="async"
@@ -48,8 +48,8 @@
                 <img
                   src="/images/default/noimage.gif"
                   alt=""
-                  width="96"
-                  height="96"
+                  width="640"
+                  height="480"
                   loading="lazy"
                   decoding="async"
                   class="object-cover w-full h-full"

--- a/themes/develop/include/entry/summary-tiny.twig
+++ b/themes/develop/include/entry/summary-tiny.twig
@@ -60,7 +60,7 @@
               <h3 class="text-gray-900 font-bold line-clamp-3">{{ entry.title }}</h3>
               <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-1">
                 <p class="text-gray-500">
-                  <span class="sr-only">投稿日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
+                  <span class="sr-only">公開日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
                       entry.datetime|date('Y年m月d日')
                     }}</time>
                 </p>

--- a/themes/develop/include/entry/summary-tiny.twig
+++ b/themes/develop/include/entry/summary-tiny.twig
@@ -56,10 +56,10 @@
                 />
               {% endif %}
             </div>
-            <div class="flex-1 flex flex-col items-start justify-center text-sm">
-              <h3 class="text-gray-900 font-bold line-clamp-3">{{ entry.title }}</h3>
+            <div class="flex-1 flex flex-col items-start justify-center">
+              <h3 class="text-gray-900 font-bold line-clamp-3 text-sm">{{ entry.title }}</h3>
               <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-1">
-                <p class="text-gray-500">
+                <p class="text-gray-500 text-sm">
                   <span class="sr-only">公開日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
                       entry.datetime|date('Y年m月d日')
                     }}</time>

--- a/themes/develop/include/entry/summary-tiny.twig
+++ b/themes/develop/include/entry/summary-tiny.twig
@@ -19,14 +19,21 @@
   )
 %}
 
-{% if entrySummary.items is not empty %}
-  <div>
-    {{ include('/admin/module/setting.twig', { moduleInfo: entrySummary.moduleInfo }) }}
-    <div class="{{ wrapper_class|default('grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 gap-4') }}">
+<div>
+  {{ include('/admin/module/setting.twig', { moduleInfo: entrySummary.moduleInfo }) }}
+
+  {% if entrySummary.items is empty %}
+    <p class="text-sm">
+      記事が見つかりませんでした。
+    </p>
+  {% endif %}
+
+  {% if entrySummary.items is not empty %}
+    <ul class="{{ wrapper_class|default('grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-4') }}" role="list">
       {% for entry in entrySummary.items %}
-        <article>
+        <li>
           <a href="{{ entry.url }}" class="flex items-start gap-2 hover:opacity-70">
-            <div class="w-1/3 aspect-square overflow-hidden rounded-md">
+            <div class="w-24 aspect-square overflow-hidden rounded-md">
               {% if entry.mainImage and entry.mainImage.path %}
                 <img
                   src="{{ entry.mainImage.path|resizeImg(192, 192) }}"
@@ -49,22 +56,24 @@
                 />
               {% endif %}
             </div>
-            <div class="flex flex-col items-start justify-center w-2/3 text-sm">
+            <div class="flex-1 flex flex-col items-start justify-center text-sm">
               <h3 class="text-gray-900 font-bold line-clamp-3">{{ entry.title }}</h3>
-              <div class="flex items-center mt-1">
+              <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-1">
                 <p class="text-gray-500">
-                  <time datetime="{{ entry.datetime|date('Y-m-d') }}">{{ entry.datetime|date('Y年m月d日') }}</time>
+                  <span class="sr-only">投稿日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
+                      entry.datetime|date('Y年m月d日')
+                    }}</time>
                 </p>
                 {% if entry.isNew %}
-                  <p class="ml-2 px-2 py-1 rounded-full bg-gray-50 text-gray-900 text-xs">
+                  <p class="px-2 py-1 rounded-full bg-gray-50 text-gray-900 text-xs">
                     NEW
                   </p>
                 {% endif %}
               </div>
             </div>
           </a>
-        </article>
+        </li>
       {% endfor %}
-    </div>
-  </div>
-{% endif %}
+    </ul>
+  {% endif %}
+</div>

--- a/themes/develop/include/entry/summary-tiny.twig
+++ b/themes/develop/include/entry/summary-tiny.twig
@@ -27,7 +27,7 @@
         <article>
           <a href="{{ entry.url }}" class="flex items-start gap-2 hover:opacity-70">
             <div class="w-1/3 aspect-square overflow-hidden rounded-md">
-              {% if entry.mainImage.path %}
+              {% if entry.mainImage and entry.mainImage.path %}
                 <img
                   src="{{ entry.mainImage.path|resizeImg(192, 192) }}"
                   width="96"

--- a/themes/develop/include/entry/tag-relational-card.twig
+++ b/themes/develop/include/entry/tag-relational-card.twig
@@ -23,7 +23,7 @@
             class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
           />
         {% endif %}
-        <h3 class="mt-3 text-gray-900 text-md md:text-lg font-bold line-clamp-2">{{ entry.title }}</h3>
+        <h3 class="mt-3 text-gray-900 text-base md:text-lg font-bold line-clamp-2">{{ entry.title }}</h3>
         <p class="mt-2 text-sm line-clamp-2">
           {{ entry.summary }}
         </p>

--- a/themes/develop/include/entry/tag-relational-card.twig
+++ b/themes/develop/include/entry/tag-relational-card.twig
@@ -1,8 +1,8 @@
 <div>
   {{ include('/admin/module/setting.twig', { moduleInfo: moduleInfo }) }}
-  <div class="grid grid-cols-1 sm:grid-cols-2 gap-8">
+  <ul class="grid grid-cols-1 sm:grid-cols-2 gap-8">
     {% for entry in items %}
-      <article>
+      <li>
         <a href="{{ entry.url }}" class="block w-full hover:opacity-70">
           {% if entry.mainImage and entry.mainImage.path %}
             <img
@@ -25,7 +25,7 @@
               class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
             />
           {% endif %}
-          <h2 class="mt-3 text-gray-900 text-lg font-bold line-clamp-2">{{ entry.title }}</h2>
+          <h3 class="mt-3 text-gray-900 text-lg font-bold line-clamp-2">{{ entry.title }}</h3>
           <p class="mt-2 text-sm line-clamp-2">
             {{ entry.summary }}
           </p>
@@ -41,18 +41,18 @@
           </div>
           {% if entry.category.items %}
             <p class="mt-2 text-gray-500 font-bold text-xs">
-              {{ entry.category.items[0].name }}
+              <span class="sr-only">カテゴリー</span>{{ entry.category.items[0].name }}
             </p>
           {% endif %}
           {% if entry.tags %}
-            <ul class="flex flex-wrap gap-3 mt-2 text-sm text-gray-500">
+            <ul class="flex flex-wrap gap-3 mt-2 text-sm text-gray-500" aria-label="タグ">
               {% for tag in entry.tags %}
                 <li><a href="{{ tag.url }}" class="hover:opacity-70">#{{ tag.name }}</a></li>
               {% endfor %}
             </ul>
           {% endif %}
         </a>
-      </article>
+      </li>
     {% endfor %}
-  </div>
+  </ul>
 </div>

--- a/themes/develop/include/entry/tag-relational-card.twig
+++ b/themes/develop/include/entry/tag-relational-card.twig
@@ -4,7 +4,7 @@
     {% for entry in items %}
       <article>
         <a href="{{ entry.url }}" class="block w-full hover:opacity-70">
-          {% if entry.mainImage.path %}
+          {% if entry.mainImage and entry.mainImage.path %}
             <img
               src="{{ entry.mainImage.path|resizeImg(686, 386) }}"
               width="343"

--- a/themes/develop/include/entry/tag-relational-card.twig
+++ b/themes/develop/include/entry/tag-relational-card.twig
@@ -1,58 +1,50 @@
-<div>
-  {{ include('/admin/module/setting.twig', { moduleInfo: moduleInfo }) }}
-  <ul class="grid grid-cols-1 sm:grid-cols-2 gap-8">
-    {% for entry in items %}
-      <li>
-        <a href="{{ entry.url }}" class="block w-full hover:opacity-70">
-          {% if entry.mainImage and entry.mainImage.path %}
-            <img
-              src="{{ entry.mainImage.path|resizeImg(686, 386) }}"
-              width="343"
-              height="193"
-              alt="{{ entry.mainImage.alt }}"
-              loading="lazy"
-              decoding="async"
-              class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
-            />
-          {% else %}
-            <img
-              src="/images/default/noimage.gif"
-              width="343"
-              height="193"
-              alt=""
-              loading="lazy"
-              decoding="async"
-              class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
-            />
-          {% endif %}
-          <h3 class="mt-3 text-gray-900 text-lg font-bold line-clamp-2">{{ entry.title }}</h3>
-          <p class="mt-2 text-sm line-clamp-2">
-            {{ entry.summary }}
+<ul class="grid grid-cols-1 sm:grid-cols-2 gap-8">
+  {% for entry in items %}
+    <li>
+      <a href="{{ entry.url }}" class="block w-full hover:opacity-70">
+        {% if entry.mainImage and entry.mainImage.path %}
+          <img
+            src="{{ entry.mainImage.path|resizeImg(686, 386) }}"
+            width="343"
+            height="193"
+            alt="{{ entry.mainImage.alt }}"
+            loading="lazy"
+            decoding="async"
+            class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
+          />
+        {% else %}
+          <img
+            src="/images/default/noimage.gif"
+            width="343"
+            height="193"
+            alt=""
+            loading="lazy"
+            decoding="async"
+            class="object-cover w-full mb-4 overflow-hidden rounded-md shadow-sm aspect-video"
+          />
+        {% endif %}
+        <h3 class="mt-3 text-gray-900 text-md md:text-lg font-bold line-clamp-2">{{ entry.title }}</h3>
+        <p class="mt-2 text-sm line-clamp-2">
+          {{ entry.summary }}
+        </p>
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-2 text-xs">
+          <p class="text-gray-500 text-sm">
+            <span class="sr-only">公開日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
+                entry.datetime|date('Y年m月d日')
+              }}</time>
           </p>
-          <div class="flex items-center mt-2 text-xs">
-            <p class="text-gray-500">
-              <time datetime="{{ entry.datetime|date('Y-m-d') }}">{{ entry.datetime|date('Y年m月d日') }}</time>
-            </p>
-            {% if entry.isNew %}
-              <p class="ml-2 px-2 py-1 rounded-full bg-gray-50 text-gray-900 text-xs">
-                NEW
-              </p>
-            {% endif %}
-          </div>
-          {% if entry.category.items %}
-            <p class="mt-2 text-gray-500 font-bold text-xs">
-              <span class="sr-only">カテゴリー</span>{{ entry.category.items[0].name }}
+          {% if entry.isNew %}
+            <p class="px-2 py-1 rounded-full bg-gray-50 text-gray-900 text-xs">
+              NEW
             </p>
           {% endif %}
-          {% if entry.tags %}
-            <ul class="flex flex-wrap gap-3 mt-2 text-sm text-gray-500" aria-label="タグ">
-              {% for tag in entry.tags %}
-                <li><a href="{{ tag.url }}" class="hover:opacity-70">#{{ tag.name }}</a></li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-        </a>
-      </li>
-    {% endfor %}
-  </ul>
-</div>
+        </div>
+        {% if entry.category.items %}
+          <p class="mt-2 text-gray-500 font-bold text-sm">
+            <span class="sr-only">カテゴリー</span>{{ entry.category.items[0].name }}
+          </p>
+        {% endif %}
+      </a>
+    </li>
+  {% endfor %}
+</ul>

--- a/themes/develop/include/entry/tag-relational-tiny.twig
+++ b/themes/develop/include/entry/tag-relational-tiny.twig
@@ -25,10 +25,10 @@
             />
           {% endif %}
         </div>
-        <div class="flex-1 flex flex-col items-start justify-center text-sm">
-          <h3 class="text-gray-900 font-bold line-clamp-3">{{ entry.title }}</h3>
+        <div class="flex-1 flex flex-col items-start justify-center">
+          <h3 class="text-gray-900 font-bold line-clamp-3 text-sm">{{ entry.title }}</h3>
           <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-1">
-            <p class="text-gray-500">
+            <p class="text-gray-500 text-sm">
               <span class="sr-only">公開日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
                   entry.datetime|date('Y年m月d日')
                 }}</time>

--- a/themes/develop/include/entry/tag-relational-tiny.twig
+++ b/themes/develop/include/entry/tag-relational-tiny.twig
@@ -5,7 +5,7 @@
         <article>
           <a href="{{ entry.url }}" class="flex items-start gap-2 hover:opacity-70">
             <div class="w-1/3 aspect-square overflow-hidden rounded-md">
-              {% if entry.mainImage.path %}
+              {% if entry.mainImage and entry.mainImage.path %}
                 <img
                   src="{{ entry.mainImage.path|resizeImg(192, 192) }}"
                   width="96"

--- a/themes/develop/include/entry/tag-relational-tiny.twig
+++ b/themes/develop/include/entry/tag-relational-tiny.twig
@@ -1,48 +1,46 @@
-{% if items is not empty %}
-  <div>
-    <div class="{{ wrapper_class|default('grid grid-cols-1 md:grid-cols-2 gap-8') }}">
-      {% for entry in items %}
-        <article>
-          <a href="{{ entry.url }}" class="flex items-start gap-2 hover:opacity-70">
-            <div class="w-1/3 aspect-square overflow-hidden rounded-md">
-              {% if entry.mainImage and entry.mainImage.path %}
-                <img
-                  src="{{ entry.mainImage.path|resizeImg(192, 192) }}"
-                  width="96"
-                  height="96"
-                  alt="{{ entry.mainImage.alt }}"
-                  loading="lazy"
-                  decoding="async"
-                  class="object-cover w-full h-full"
-                />
-              {% else %}
-                <img
-                  src="/images/default/noimage.gif"
-                  alt=""
-                  width="96"
-                  height="96"
-                  loading="lazy"
-                  decoding="async"
-                  class="object-cover w-full h-full"
-                />
-              {% endif %}
-            </div>
-            <div class="flex flex-col items-start justify-center w-2/3 text-sm">
-              <h3 class="text-gray-900 font-bold line-clamp-3">{{ entry.title }}</h3>
-              <div class="flex items-center mt-1">
-                <p class="text-gray-500">
-                  <time datetime="{{ entry.datetime|date('Y-m-d') }}">{{ entry.datetime|date('Y年m月d日') }}</time>
-                </p>
-                {% if entry.isNew %}
-                  <p class="ml-2 px-2 py-1 rounded-full bg-gray-50 text-gray-900 text-xs">
-                    NEW
-                  </p>
-                {% endif %}
-              </div>
-            </div>
-          </a>
-        </article>
-      {% endfor %}
-    </div>
-  </div>
-{% endif %}
+<ul class="grid grid-cols-1 sm:grid-cols-2 gap-8">
+  {% for entry in items %}
+    <li>
+      <a href="{{ entry.url }}" class="flex items-start gap-2 hover:opacity-70">
+        <div class="w-24 aspect-square overflow-hidden rounded-md">
+          {% if entry.mainImage and entry.mainImage.path %}
+            <img
+              src="{{ entry.mainImage.path|resizeImg(192, 192) }}"
+              width="192"
+              height="192"
+              alt="{{ entry.mainImage.alt }}"
+              loading="lazy"
+              decoding="async"
+              class="object-cover w-full h-full"
+            />
+          {% else %}
+            <img
+              src="/images/default/noimage.gif"
+              alt=""
+              width="640"
+              height="480"
+              loading="lazy"
+              decoding="async"
+              class="object-cover w-full h-full"
+            />
+          {% endif %}
+        </div>
+        <div class="flex-1 flex flex-col items-start justify-center text-sm">
+          <h3 class="text-gray-900 font-bold line-clamp-3">{{ entry.title }}</h3>
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-1">
+            <p class="text-gray-500">
+              <span class="sr-only">公開日</span><time datetime="{{ entry.datetime|date('Y-m-d') }}">{{
+                  entry.datetime|date('Y年m月d日')
+                }}</time>
+            </p>
+            {% if entry.isNew %}
+              <p class="px-2 py-1 rounded-full bg-gray-50 text-gray-900 text-xs">
+                NEW
+              </p>
+            {% endif %}
+          </div>
+        </div>
+      </a>
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
コミットメッセージだけでは伝わりずらいところについて補足します。

## 記事一覧での article と の使い分けについて

### article を採用するケース
ページの主役となる一覧（検索結果、カテゴリ一覧など）
ユーザーが「記事を読む／探す」ことが主目的となるため、各アイテムを独立したコンテンツとして扱います。

###  ul / li を採用するケース
補助的な記事リスト（関連記事、サイドバーの新着記事など）
「次に読む記事を選ぶ」ためのナビゲーションとしての役割が強いため、リスト構造を採用しました。
これにより、スクリーンリーダー等で「リスト」として認識され、スキップ操作などが容易になります。
