### PR TITLE
fix: Twigテンプレートのフィールド参照に.valueを追加

### DIFF
--- a/themes/develop/include/body-end.twig
+++ b/themes/develop/include/body-end.twig
@@ -1,6 +1,6 @@
 {% set blogField = module('V2_Blog_Field', null, { bid: RBID }) %}
 
-{{ blogField.fields.script_body_end|raw }}
+{{ blogField.fields.script_body_end.value|raw }}
 
 <!-- iOS Chromeの対応 -->
 <script>

--- a/themes/develop/include/body-start.twig
+++ b/themes/develop/include/body-start.twig
@@ -1,3 +1,3 @@
 {% set blogField = module('V2_Blog_Field', null, { bid: RBID }) %}
 
-{{ blogField.fields.script_body_start|raw }}
+{{ blogField.fields.script_body_start.value|raw }}

--- a/themes/develop/include/head/meta.twig
+++ b/themes/develop/include/head/meta.twig
@@ -39,10 +39,10 @@
 {% if ogp.image %}
   <meta name="twitter:image" content="{{ ogp.image }}" />
 {% endif %}
-{% if blogField.fields.twitter_creator %}
+{% if blogField.fields.twitter_creator.value %}
   <meta name="twitter:creator" content="@{{ blogField.fields.twitter_creator.value }}" />
 {% endif %}
 
-{% if blogField.fields.google_site_verification %}
+{% if blogField.fields.google_site_verification.value %}
   <meta name="google-site-verification" content="{{ blogField.fields.google_site_verification.value }}" />
 {% endif %}

--- a/themes/develop/include/head/robots.twig
+++ b/themes/develop/include/head/robots.twig
@@ -2,9 +2,9 @@
 {% set categoryField = module('V2_Category_Field', null, { cid: CID }) %}
 {% set entryField = module('V2_Entry_Field', null, { eid: EID }) %}
 
-{% set isNoindexBlog = blogField.fields and blogField.fields.blog_meta_robots == 'noindex' %}
-{% set isNoindexCategory = categoryField.fields and categoryField.fields.category_meta_robots == 'noindex' %}
-{% set isNoindexEntry = entryField.fields and entryField.fields.entry_meta_robots == 'noindex' %}
+{% set isNoindexBlog = blogField.fields and blogField.fields.blog_meta_robots.value == 'noindex' %}
+{% set isNoindexCategory = categoryField.fields and categoryField.fields.category_meta_robots.value == 'noindex' %}
+{% set isNoindexEntry = entryField.fields and entryField.fields.entry_meta_robots.value == 'noindex' %}
 {% set isTagPage = TAG is not empty %}
 {% set isKeywordPage = KEYWORD is not empty %}
 {% set isDatePage = DATE is not empty %}


### PR DESCRIPTION
blogField.fields.{key}はオブジェクト(value/array構造)を返すため、 値を参照する際は.valueが必要。これがない場合、スクリプト出力が
機能しない・noindex判定が常にfalse・空値でもmetaタグが出力される
などの不具合が発生していた。